### PR TITLE
Upgrade project to Compose 1.8.x | Further optimisations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(baseLibs.plugins.kotlinMultiplatform) apply false
     alias(baseLibs.plugins.composeMultiplatform) apply false
     alias(baseLibs.plugins.composeCompiler) apply false
+    alias(baseLibs.plugins.composeHotreload) apply false
     alias(baseLibs.plugins.mavenPublish) apply false
     alias(baseLibs.plugins.versionCatalogUpdate) apply false
     alias(baseLibs.plugins.aboutLibraries) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 androidx-benchmark = "1.3.4"
-haze = "1.6.0-beta01"
+haze = "1.6.2"
 
 [plugins]
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "androidx-benchmark" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Sun May 25 15:59:22 CEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/sample/gradle.properties
+++ b/sample/gradle.properties
@@ -1,1 +1,2 @@
 com.mikepenz.targets.enabled=false
+com.mikepenz.hotreload.enabled=true

--- a/sample/src/commonMain/kotlin/App.kt
+++ b/sample/src/commonMain/kotlin/App.kt
@@ -142,7 +142,6 @@ fun App() {
                             .let {
                                 if (useHaze) it.clip(MaterialTheme.shapes.large).hazeEffect(hazeState, HazeMaterials.thin()) else it
                             },
-                        colors = LibraryDefaults.libraryColors(backgroundColor = Color.Transparent),
                         contentPadding = contentPadding
                     )
                 } else {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver") version "1.0.0"
+}
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
@@ -17,7 +21,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.3.3")
+            from("com.mikepenz:version-catalog:0.3.9")
         }
     }
 }


### PR DESCRIPTION
- update to compose 1.8.x releases
- update project and include compose hot reload
- update to gradle 8.14.1
- upgrade haze
- upgrade aboutlibraries